### PR TITLE
don't require special sampling branch to minimise recompilation

### DIFF
--- a/netket_fidelity/infidelity/overlap/operator.py
+++ b/netket_fidelity/infidelity/overlap/operator.py
@@ -1,5 +1,8 @@
 from typing import Optional
+
 import jax.numpy as jnp
+
+import flax
 
 from netket import jax as nkjax
 from netket.operator import AbstractOperator
@@ -64,12 +67,12 @@ def InfidelityUPsi(
     dtype: Optional[DType] = None,
 ):
 
-    logpsiU = nkjax.HashablePartial(_logpsi_U, state._apply_fun, U)
+    logpsiU = nkjax.HashablePartial(_logpsi_U, state._apply_fun)
     target = MCState(
         sampler=state.sampler,
         apply_fun=logpsiU,
         n_samples=state.n_samples,
-        variables=state.variables,
+        variables=flax.core.copy(state.variables, {'unitary':U})
     )
 
     return InfidelityOperatorStandard(target, cv_coeff=cv_coeff, dtype=dtype)

--- a/netket_fidelity/utils/sampling_Ustate.py
+++ b/netket_fidelity/utils/sampling_Ustate.py
@@ -1,8 +1,39 @@
 import jax
 
+import flax
 
-def _logpsi_U(apply_fun, U, variables, x):
+
+def _logpsi_U(apply_fun, variables, x, *args):
+    """
+    This should be used as a wrapper to the original apply function, adding
+    to the `variables` dictionary (in model_state) a new key `unitary` with
+    a jax-compatible operator.
+    """
+    variables_applyfun, U = flax.core.pop(variables, 'unitary')
+
     xp, mels = U.get_conn_padded(x)
-    logpsi_xp = apply_fun(variables, xp)
+    logpsi_xp = apply_fun(variables_applyfun, xp, *args)
 
     return jax.scipy.special.logsumexp(logpsi_xp, axis=-1, b=mels)
+
+#
+# from flax import linen as nn
+#
+# class LogUPsi(nn.Module):
+#     """
+#     A Flax module working a bit like logpsi_U above.
+#
+#     Just set a vs.model_state = {'unitary':{'operator':your_jax_operator}}
+#     """
+#     log_psi : nn.Module
+#
+#     @nn.compact
+#     def __call__(self, x, *args):
+#         U = self.variable('unitary', 'operator', lambda : None)
+#         if U.value is not None:
+#             xp, mels = U.value.get_conn_padded(x)
+#             logpsi_xp = self.log_psi(xp, *args)
+#             return jax.scipy.special.logsumexp(logpsi_xp, axis=-1, b=mels)
+#         else:
+#             return self.log_psi(x, *args)
+#


### PR DESCRIPTION
This PR avoids the need for a special branch of netket to minimise recompilation when sampling from a target state.

Essentially, we now set the unitary we want to sample from as a non-differentiable `model_state` argument of the MCState, which is why I had added this convoluted thing in the first place to netket (but I forgot about it..)